### PR TITLE
Fuck windows

### DIFF
--- a/SourceCode/WebServer/dev.windows.Dockerfile
+++ b/SourceCode/WebServer/dev.windows.Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:5.4.1-jdk12
+
+RUN mkdir -p /root/src/api
+WORKDIR /root/src/api
+
+COPY . .
+
+RUN gradle dependencies
+
+ENTRYPOINT ["gradle","bootRun"]


### PR DESCRIPTION
@toquoccuong55 cannot run `./gradlew` on his Windows, so we must use `gradle` docker image for Windows, that's suck!! 😠 